### PR TITLE
Added airline endpoint for API

### DIFF
--- a/app/Http/Controllers/Api/V1/AirlineAPIController.php
+++ b/app/Http/Controllers/Api/V1/AirlineAPIController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Models\Airline;
+use App\Http\Resources\V1\AirlineResource;
+use App\Http\Resources\V1\AirlineCollection;
+
+class AirlineAPIController extends Controller
+{
+
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum');
+    }
+
+    public function index(){
+        return new AirlineCollection(Airline::all());
+    }
+
+    public function show(Airline $airline){
+        return new AirlineResource($airline);
+    }
+
+    public function store(Request $request){
+        $get_asking_user = request()->user('sanctum');
+
+
+        if($get_asking_user->can('add airlines')){ // Check user permission
+            if($request->getMethod() == "POST"){
+
+                $validated = $request->validate([
+                    'name' => 'required|max:50|unique:airlines', // Example Airline
+                    'prefix' => 'required|min:2|max:2|unique:airlines|uppercase', // EV
+                    'icao_callsign' => 'required|regex:/^[a-zA-Z]+$/u|min:3|max:3|unique:airlines|uppercase', // EVA
+                    'atc_callsign' => 'required|regex:/^[a-zA-Z]+$/u|max:25|unique:airlines' // EXAMPLE
+                ]);
+                Airline::create($validated);
+
+            }
+
+            return response()->json([
+                'message' => 'New airline ' . $request->name . ' stored succesfully.'
+            ]);
+
+        } else { // If user does not have permission, throw a 401
+            return response()->json(['error' => 'Missing "add airlines" permission. Unauthenticated.'], 401);
+        }
+    }
+}

--- a/app/Http/Resources/V1/AirlineCollection.php
+++ b/app/Http/Resources/V1/AirlineCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class AirlineCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/V1/AirlineResource.php
+++ b/app/Http/Resources/V1/AirlineResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AirlineResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'prefix' => $this->prefix,
+            'icaoCallsign' => $this->icao_callsign,
+            'atcCallsign' => $this->atc_callsign,
+            'createdAt' => $this->created_at,
+            'updatedAt' => $this->updated_at
+        ];
+    }
+}

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -10,7 +10,10 @@ class Airline extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name'
+        'name',
+        'prefix',
+        'icao_callsign',
+        'atc_callsign'
     ];
 
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\Api\V1\ApiTestController;
+use App\Http\Controllers\Api\V1\AirlineAPIController;
 
 /*
 |--------------------------------------------------------------------------
@@ -26,4 +27,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::group(['prefix' => 'v1', 'namespace' => 'App\Http\Controllers\Api\V1', 'middleware' => 'auth:sanctum' ], function() {
     Route::get('apitest', [ApiTestController::class, 'index'])->name('apitest');
+    Route::apiResource('airlines', AirlineAPIController::class);
 });


### PR DESCRIPTION
You can now create airlines through a POST request to /api/v1/airlines

This is all rather experimental and not yet completed.