### PR TITLE
Airline awareness

### DIFF
--- a/app/Http/Controllers/AircraftController.php
+++ b/app/Http/Controllers/AircraftController.php
@@ -37,8 +37,11 @@ class AircraftController extends Controller
         $page = min(max(1, $page), $maxPages);
         $offset = ($page -1) * $limit;
 
+        $currentActiveAirline = $request->session()->get('activeairline');
+
         $fleet = Aircraft::query()
         ->orderBy('created_at', 'DESC')
+        ->where('used_by', '=', $currentActiveAirline->airline->id )
         ->offset($offset)
         ->limit($limit)
         ->get();

--- a/app/Http/Controllers/AirlineController.php
+++ b/app/Http/Controllers/AirlineController.php
@@ -6,7 +6,5 @@ use Illuminate\Http\Request;
 
 class AirlineController extends Controller
 {
-    public function changeActiveAirline(Request $request) {
-        return view('airlines.airlineswitcher');
-    }
+
 }

--- a/app/Http/Controllers/AirlineMembershipController.php
+++ b/app/Http/Controllers/AirlineMembershipController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AirlineMembership;
+use Illuminate\Http\Request;    
+
+class AirlineMembershipController extends Controller
+{
+
+    public function changeActiveAirline(Request $request) {
+        $currentActiveAirline = $request->session()->get('activeairlineid');
+        $memberships = AirlineMembership::where('user_id', '=', auth()->user()->id)->get();
+
+        if($request->getMethod() == "POST"){
+            
+        }
+
+        return view('airlines.airlineswitcher', [ 'current_active' => $currentActiveAirline, 'memberships' => $memberships ]);
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(AirlineMembership $airlineMembership)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(AirlineMembership $airlineMembership)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, AirlineMembership $airlineMembership)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(AirlineMembership $airlineMembership)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/AirlineMembershipController.php
+++ b/app/Http/Controllers/AirlineMembershipController.php
@@ -4,74 +4,35 @@ namespace App\Http\Controllers;
 
 use App\Models\AirlineMembership;
 use Illuminate\Http\Request;    
+use Illuminate\Validation\ValidationException;
+use Session;
 
 class AirlineMembershipController extends Controller
 {
-
     public function changeActiveAirline(Request $request) {
-        $currentActiveAirline = $request->session()->get('activeairlineid');
-        $memberships = AirlineMembership::where('user_id', '=', auth()->user()->id)->get();
-
         if($request->getMethod() == "POST"){
-            
+            // Get data from the form.
+            $selectedTargetAirline = AirlineMembership::where('airline_id', '=', $request->post('airline_id'))->where('user_id', '=', auth()->user()->id)->first();
+
+            //dd($selectedTargetAirline);
+
+            // Double check if the user is member
+            if ($selectedTargetAirline->count() == 0) {
+                throw ValidationException::withMessages(['airline_id' => 'You are not a member of this airline.']);
+            } else {
+                
+                $request->session()->forget('activeairline');
+                Session::put('activeairline', $selectedTargetAirline);
+                $currentActiveAirline = $request->session()->get('activeairline');
+                //dump($currentActiveAirline->airline->name);
+                return redirect()->route('changeactiveairline');
+            }
         }
 
+        $currentActiveAirline = $request->session()->get('activeairline');
+
+        // We need this later to check if the user is not member of any airlines at all.
+        $memberships = AirlineMembership::where('user_id', '=', auth()->user()->id)->get();
         return view('airlines.airlineswitcher', [ 'current_active' => $currentActiveAirline, 'memberships' => $memberships ]);
-    }
-
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(AirlineMembership $airlineMembership)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(AirlineMembership $airlineMembership)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, AirlineMembership $airlineMembership)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(AirlineMembership $airlineMembership)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -31,7 +31,7 @@ class LoginController extends Controller
         // Set the first airline found for the user in the DB as the active airline.
         // FIXME/TODO: What to do if no airline exists??
         $firstAirlineFound = AirlineMembership::where('user_id', '=', auth()->user()->id)->first();
-        $request->session()->put('activeairlineid', $firstAirlineFound);
+        $request->session()->put('activeairline', $firstAirlineFound);
 
         return redirect()->route('dashboard');
     }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\AirlineMembership;
+
 use Illuminate\Http\Request;
 
 class LoginController extends Controller
@@ -26,7 +28,11 @@ class LoginController extends Controller
              return back()->with('status', 'Invalid login details');
         }
 
-        
+        // Set the first airline found for the user in the DB as the active airline.
+        // FIXME/TODO: What to do if no airline exists??
+        $firstAirlineFound = AirlineMembership::where('user_id', '=', auth()->user()->id)->first();
+        $request->session()->put('activeairlineid', $firstAirlineFound);
+
         return redirect()->route('dashboard');
     }
 }

--- a/app/Models/AirlineMembership.php
+++ b/app/Models/AirlineMembership.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AirlineMembership extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'airline_id',
+        'user_id'
+    ];
+
+    public function airline()
+    {
+        return $this->belongsTo(Airline::class, 'airline_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+}

--- a/database/migrations/2024_04_07_101000_create_airline_memberships_table.php
+++ b/database/migrations/2024_04_07_101000_create_airline_memberships_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('airline_memberships', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('airline_id');
+            $table->foreign('airline_id')->references('id')->on('airlines');
+            $table->foreignId('user_id');
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('airline_memberships');
+    }
+};

--- a/database/seeders/AircraftSeeder.php
+++ b/database/seeders/AircraftSeeder.php
@@ -85,5 +85,29 @@ class AircraftSeeder extends Seeder
             'created_at' => Carbon::now()->toDateTimeString(),
             'updated_at' => Carbon::now()->toDateTimeString(),
         ]);
+
+        // One Aircraft for Third VA with the same tail number!
+        DB::table('aircraft')->insert([
+            'registration' => "D-EXAM",
+            'manufacturer' => "Boeing",
+            'model' => '737-800',
+            'current_loc' => 'EFHK',
+            'remarks' => "Special paint scheme",
+            'used_by' => 3,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+
+        DB::table('aircraft')->insert([
+            'registration' => "N1338L",
+            'manufacturer' => "Cirrus",
+            'model' => 'SR22',
+            'current_loc' => 'KMIA',
+            'remarks' => "Special paint scheme",
+            'used_by' => 2,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+
     }
 }

--- a/database/seeders/AirlineMembershipSeeder.php
+++ b/database/seeders/AirlineMembershipSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class AirlineMembershipSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Max Mustermann is member of the two demo airlines
+        DB::table('airline_memberships')->insert([
+            'airline_id' => "2",
+            'user_id' => "2",
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+        DB::table('airline_memberships')->insert([
+            'airline_id' => "1",
+            'user_id' => "2",
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
+    }
+}

--- a/database/seeders/AirlineMembershipSeeder.php
+++ b/database/seeders/AirlineMembershipSeeder.php
@@ -28,5 +28,11 @@ class AirlineMembershipSeeder extends Seeder
             'created_at' => Carbon::now()->toDateTimeString(),
             'updated_at' => Carbon::now()->toDateTimeString(),
         ]);
+        DB::table('airline_memberships')->insert([
+            'airline_id' => "3",
+            'user_id' => "1",
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ]);
     }
 }

--- a/database/seeders/AirlinesSeeder.php
+++ b/database/seeders/AirlinesSeeder.php
@@ -33,5 +33,14 @@ class AirlinesSeeder extends Seeder
             'created_at' => Carbon::now()->toDateTimeString(),
             'updated_at' => Carbon::now()->toDateTimeString()
         ]);
+        DB::table('airlines')->insert([
+            'name' => "Third VA",
+            'prefix' => "TV",
+            'icao_callsign' => 'TVA',
+            'atc_callsign' => 'THIRD',
+            'unit_is_lbs' => true,
+            'created_at' => Carbon::now()->toDateTimeString(),
+            'updated_at' => Carbon::now()->toDateTimeString()
+        ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,7 +19,8 @@ class DatabaseSeeder extends Seeder
             AirlinesSeeder::class,
             AirportsSeeder::class,
             AircraftSeeder::class,
-            UserAndPermissionsSeeder::class
+            UserAndPermissionsSeeder::class,
+            AirlineMembershipSeeder::class
         ]);
     }
 }

--- a/resources/views/airlines/airlineswitcher.blade.php
+++ b/resources/views/airlines/airlineswitcher.blade.php
@@ -4,7 +4,7 @@
             <h1 class="display-4 mb-4">Switch active airline</h1>
             <p class="lead">Change the current airline for your active session.</p>
             <p>
-                Current active airline: <b>Bla</b>
+                Current active airline: <b>{{ $current_active->airline->name }}</b>
             </p>
 
             <form method=POST class="row g-2" action="{{ route('changeactiveairline') }}">
@@ -12,7 +12,9 @@
                 <div class="col-md-4">
                     <label for="airline" class="form-label">Choose an airline to be active</label>
                     <select id="airline" class="form-select" required aria-label="Select the online network">
-                        <option value="all">All</option>
+                        @foreach($memberships as $membership)
+                            <option name="{{ $membership->airline->id }}">{{ $membership->airline->name }} - {{ $membership->airline->icao_callsign }}</option>
+                        @endforeach
                     </select>
                 </div>
                 <div class="col-12">

--- a/resources/views/airlines/airlineswitcher.blade.php
+++ b/resources/views/airlines/airlineswitcher.blade.php
@@ -4,16 +4,27 @@
             <h1 class="display-4 mb-4">Switch active airline</h1>
             <p class="lead">Change the current airline for your active session.</p>
             <p>
-                Current active airline: <b>{{ $current_active->airline->name }}</b>
+                Current active airline: <b>{{ session('activeairline')->airline->name }}</b>
             </p>
+
+            @if($errors->any())
+            <div class="alert alert-danger">
+                Error during request:
+                <ul>
+                    @foreach($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+            @endif
 
             <form method=POST class="row g-2" action="{{ route('changeactiveairline') }}">
                 @csrf
                 <div class="col-md-4">
                     <label for="airline" class="form-label">Choose an airline to be active</label>
-                    <select id="airline" class="form-select" required aria-label="Select the online network">
+                    <select id="airline" name="airline_id" class="form-select" required aria-label="Select the online network">
                         @foreach($memberships as $membership)
-                            <option name="{{ $membership->airline->id }}">{{ $membership->airline->name }} - {{ $membership->airline->icao_callsign }}</option>
+                            <option name="{{ $membership->airline->id }}" value="{{ $membership->airline->id }}">{{ $membership->airline->name }} - {{ $membership->airline->icao_callsign }}</option>
                         @endforeach
                     </select>
                 </div>

--- a/resources/views/fleet/edit.blade.php
+++ b/resources/views/fleet/edit.blade.php
@@ -18,7 +18,7 @@
         
             <form action="{{ route('editfleet', $aircraft->id) }}" method="POST" class="row g-3">
                 @csrf
-                <input type="hidden" id="used_by" name="used_by" value="1" hidden required>
+                <input type="hidden" id="used_by" name="used_by" value="{{ session('activeairline')->airline->id }}" hidden required>
                 <div class="col-md-4">
                     <label for="registration" class="form-label">Registration (tail number)</label>
                     <input type="text" class="form-control" id="registration" name="registration" value="{{ $aircraft->registration }}" maxlength="6" required>

--- a/resources/views/fleet/index.blade.php
+++ b/resources/views/fleet/index.blade.php
@@ -69,7 +69,7 @@
                             @csrf
                             <input type="hidden" id="in_service_since" name="in_service_since" value="2023-05-05" hidden
                                 required>
-                            <input type="hidden" id="used_by" name="used_by" value="1" hidden required>
+                            <input type="hidden" id="used_by" name="used_by" value="{{ session('activeairline')->airline->id }}" hidden required>
                             <div class="row">
                                 <div class="mb-3">
                                     <label for="registration" class="form-label">Registration (tail number)</label>
@@ -116,9 +116,9 @@
                     <thead class="table-dark">
                         <tr>
                             <th scope="col" class="text-center">Tail number</th>
-                            <th scope="col" class="text-center">Airline</th>
                             <th scope="col" class="text-center">Type</th>
                             <th scope="col" class="text-center">Current location</th>
+                            <th scope="col" class="text-center">Logged hours</th>
                             @can('edit aircraft')
                             <th scope="col" class="text-center">Actions</th>
                             @endcan
@@ -129,8 +129,6 @@
                             <tr>
                                 <th scope="row" class="text-center" @if( $aircraft->active == 0) style="color: gray" @endif>{{ $aircraft->registration }}</th>
         
-                                <td class="text-center" @if( $aircraft->active == 0) style="color: gray" @endif>{{ $aircraft->airline->name }}</td>
-        
                                 <td class="text-center" @if( $aircraft->active == 0) style="color: gray" @endif>{{ $aircraft->full_type }}</td>
         
                                 <td class="text-center" @if( $aircraft->active == 0) style="color: gray" @endif>@if(is_null($aircraft->current_loc))
@@ -139,6 +137,7 @@
                                 @else
                                     {{ $aircraft->current_loc }}
                                 @endif
+                                <td class="text-center" @if( $aircraft->active == 0) style="color: gray" @endif>TODO</td>
                                 @can('edit aircraft')
                                 <td class="text-center"><a href="{{ route('editfleet', $aircraft->id) }}">Edit</a></td>
                                 @endcan

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -53,14 +53,14 @@
                     @auth
                     <div class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownUser" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            {{ Auth::user()->name }}
+                            {{ Auth::user()->name }} | EVA
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownUser">
                             <li><a class="dropdown-item" href="{{ route('dashboard') }}">Dashboard</a></li>
                             <li><a class="dropdown-item" href="#">Edit profile</a></li>
                             <li><a class="dropdown-item" href="#">Settings</a></li>
                             <li><hr class="dropdown-divider"></li>
-                            <li><a class="dropdown-item" href="{{ route('changeactiveairline') }}">Current airline: Lufthansa</a></li>
+                            <li><a class="dropdown-item" href="{{ route('changeactiveairline') }}">Current airline: Example VA</a></li>
                             <li>
                                 <form action="{{ route('logout') }}" method="post">
                                     @csrf

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -53,14 +53,14 @@
                     @auth
                     <div class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownUser" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            {{ Auth::user()->name }} | EVA
+                            {{ Auth::user()->name }} | {{ session('activeairline')->airline->icao_callsign }}
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownUser">
                             <li><a class="dropdown-item" href="{{ route('dashboard') }}">Dashboard</a></li>
                             <li><a class="dropdown-item" href="#">Edit profile</a></li>
                             <li><a class="dropdown-item" href="#">Settings</a></li>
                             <li><hr class="dropdown-divider"></li>
-                            <li><a class="dropdown-item" href="{{ route('changeactiveairline') }}">Current airline: Example VA</a></li>
+                            <li><a class="dropdown-item" href="{{ route('changeactiveairline') }}">Current airline: {{ session('activeairline')->airline->name }}</a></li>
                             <li>
                                 <form action="{{ route('logout') }}" method="post">
                                     @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,8 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\FlightController;
 use App\Http\Controllers\AircraftController;
 use App\Http\Controllers\AirlineController;
+use App\Http\Controllers\AirlineMembershipController;
+
 
 Route::get('/auth/register', [RegisterController::class, 'index'])->name('register');
 Route::post('/auth/register', [RegisterController::class, 'store']);
@@ -19,7 +21,7 @@ Route::post('/auth/login', [LoginController::class, 'store']);
 Route::post('/auth/logout', [LogoutController::class, 'store'])->name('logout');
 
 Route::get('/user/dashboard', [DashboardController::class, 'index'])->name('dashboard');
-Route::match(['GET', 'POST'], '/user/switchactiveairline', [AirlineController::class, 'changeActiveAirline'])->name('changeactiveairline');
+Route::match(['GET', 'POST'], '/user/switchactiveairline', [AirlineMembershipController::class, 'changeActiveAirline'])->name('changeactiveairline');
 
 
 Route::match(['GET', 'POST'], '/user/flights/add', [FlightController::class, 'addFlight'])->name('addflight');


### PR DESCRIPTION
This is a big patch:

* Add new table and model "AirlineMembership" which stores airline_id and user_id, to know the relationship between the user
* Adds seeders for example data
* Login finds the first found airline and sets it in the session as a eloquent model
* This variable can be changed using the UI -> User -> Change AIrline
* The active airline gets diplayed in the navbar all the time
* Fleet Manager is aware of these airline ids